### PR TITLE
Fix register_uninstall_hook notice

### DIFF
--- a/mw-polylang-theme-strings.php
+++ b/mw-polylang-theme-strings.php
@@ -69,8 +69,8 @@
 
         private function Plugin_Hooks_Init()
         {
-            register_activation_hook($this->Path_Get('plugin_file_index'), array('MW_Polylang_Theme_Strings', 'Install'));
-            register_uninstall_hook($this->Path_Get('plugin_file_index'), array('MW_Polylang_Theme_Strings', 'Uninstall'));
+            register_activation_hook($this->Path_Get('plugin_file_index'), 'Install');
+            register_uninstall_hook($this->Path_Get('plugin_file_index'), 'Uninstall');
 
             if (!is_admin() && function_exists(self::$pll_f))
             {


### PR DESCRIPTION
Fix `register_uninstall_hook was called incorrectly. Only a static class method or function can be used in an uninstall hook. Please see Debugging in WordPress for more information. (This message was added in version 3.1.0.) ` notice.